### PR TITLE
refactor(version): change strapi image version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM strapi/strapi:3.5.4
+FROM strapi/strapi:latest
 WORKDIR /app
 COPY . . 
 RUN yarn


### PR DESCRIPTION
It should be great if we force to get the latest stable docker image of strapi in order to don't have to change it every time strapi release a new one.