### PR TITLE
refactor: change strapi v3.5.4 to v3.6.1 & change database informations in the README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM strapi/strapi:3.5.4
+FROM strapi/strapi:3.6.1
 WORKDIR /app
 COPY ./<my-project> .  # EDIT ME !
 COPY .env .env

--- a/README.md
+++ b/README.md
@@ -10,26 +10,42 @@ Before you begin, this guide assumes you have create a Strapi app with Qovery's 
 1. Clone the repository created by Qovey
 2. Initialize Strapi in the project cloned with one of the following command:
 
-        yarn create strapi-app <my-project> --quickstart
-  
-      or
-    
-        npx create-strapi-app <my-project> --quickstart
+      ```bash
+      yarn create strapi-app <my-project> --quickstart
+      
+      OR
+      
+      npx create-strapi-app <my-project> --quickstart
+      ```
     
 3. Edit Dockerfile in order to have the path of the project initilized instead of 
   
-        COPY ./<my-project> .
+      ```bash
+      COPY ./<my-project> .
+      ```
         
 4. Edit < my-project >/config/database.js to have:
 
-        settings: {
-        client: env("DATABASE_CLIENT", "mysql"),
-        host: env("DATABASE_HOST", "0.0.0.0"),
-        port: env.int("DATABASE_PORT", 3306),
-        database: env("DATABASE_NAME", "strapi"),
-        username: env("DATABASE_USERNAME", "strapi"),
-        password: env("DATABASE_PASSWORD", "strapi"),
-        }
+      ```js
+      module.exports = ({ env }) => ({
+        defaultConnection: "default",
+        connections: {
+          default: {
+            connector: "bookshelf",
+            settings: {
+              client: env("DATABASE_HOST", "postgres"),
+              host: env("DATABASE_HOST", "localhost"),
+              port: env.int("DATABASE_PORT", 5432),
+              database: env("DATABASE_NAME", "strapi"),
+              username: env("DATABASE_USERNAME", "strapi"),
+              password: env("DATABASE_PASSWORD", "strapi"),
+              ssl: false,
+            },
+            options: {},
+          },
+        },
+      });
+      ```
         
 6. Push the changes on your remote branch
 7. Wait for Qovery to deploy your app 8)


### PR DESCRIPTION
As the v3.6.1 is stable now, I think we can switch to 😄 

I add little changes to the README in order to have better code highlight and more details for the database.js configuration